### PR TITLE
Add an explicit scala-library dep.

### DIFF
--- a/3rdparty/jvm/default.lock
+++ b/3rdparty/jvm/default.lock
@@ -4,7 +4,8 @@
             "group": "com.google.code.findbugs",
             "artifact": "jsr305",
             "version": "3.0.2",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -21,7 +22,8 @@
             "group": "com.google.errorprone",
             "artifact": "error_prone_annotations",
             "version": "2.7.1",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -38,7 +40,8 @@
             "group": "com.google.guava",
             "artifact": "failureaccess",
             "version": "1.0.1",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -55,44 +58,51 @@
             "group": "com.google.guava",
             "artifact": "guava",
             "version": "31.0.1-jre",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "com.google.guava",
                 "artifact": "listenablefuture",
                 "version": "9999.0-empty-to-avoid-conflict-with-guava",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.j2objc",
                 "artifact": "j2objc-annotations",
                 "version": "1.3",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.code.findbugs",
                 "artifact": "jsr305",
                 "version": "3.0.2",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.errorprone",
                 "artifact": "error_prone_annotations",
                 "version": "2.7.1",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.checkerframework",
                 "artifact": "checker-qual",
                 "version": "3.12.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.guava",
                 "artifact": "failureaccess",
                 "version": "1.0.1",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -100,37 +110,43 @@
                 "group": "com.google.guava",
                 "artifact": "listenablefuture",
                 "version": "9999.0-empty-to-avoid-conflict-with-guava",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.j2objc",
                 "artifact": "j2objc-annotations",
                 "version": "1.3",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.code.findbugs",
                 "artifact": "jsr305",
                 "version": "3.0.2",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.errorprone",
                 "artifact": "error_prone_annotations",
                 "version": "2.7.1",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.checkerframework",
                 "artifact": "checker-qual",
                 "version": "3.12.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "com.google.guava",
                 "artifact": "failureaccess",
                 "version": "1.0.1",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "com.google.guava_guava_31.0.1-jre.jar",
@@ -146,7 +162,8 @@
             "group": "com.google.guava",
             "artifact": "listenablefuture",
             "version": "9999.0-empty-to-avoid-conflict-with-guava",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -163,7 +180,8 @@
             "group": "com.google.j2objc",
             "artifact": "j2objc-annotations",
             "version": "1.3",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -180,7 +198,8 @@
             "group": "com.lihaoyi",
             "artifact": "acyclic_2.13",
             "version": "0.2.1",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -197,7 +216,8 @@
             "group": "org.checkerframework",
             "artifact": "checker-qual",
             "version": "3.12.0",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -214,14 +234,16 @@
             "group": "org.scala-lang.modules",
             "artifact": "scala-xml_2.13",
             "version": "1.3.0",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -229,7 +251,8 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scala-lang.modules_scala-xml_2.13_1.3.0.jar",
@@ -245,7 +268,8 @@
             "group": "org.scala-lang",
             "artifact": "scala-library",
             "version": "2.13.6",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -262,14 +286,16 @@
             "group": "org.scala-lang",
             "artifact": "scala-reflect",
             "version": "2.13.6",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -277,7 +303,8 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scala-lang_scala-reflect_2.13.6.jar",
@@ -293,20 +320,23 @@
             "group": "org.scalactic",
             "artifact": "scalactic_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -314,13 +344,15 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalactic_scalactic_2.13_3.2.10.jar",
@@ -336,7 +368,8 @@
             "group": "org.scalatest",
             "artifact": "scalatest-compatible",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [],
         "dependencies": [],
@@ -353,38 +386,44 @@
             "group": "org.scalatest",
             "artifact": "scalatest-core_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -392,31 +431,36 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-core_2.13_3.2.10.jar",
@@ -432,26 +476,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-diagrams_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -459,37 +507,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-diagrams_2.13_3.2.10.jar",
@@ -505,26 +559,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-featurespec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -532,37 +590,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-featurespec_2.13_3.2.10.jar",
@@ -578,26 +642,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-flatspec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -605,37 +673,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-flatspec_2.13_3.2.10.jar",
@@ -651,26 +725,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-freespec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -678,37 +756,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-freespec_2.13_3.2.10.jar",
@@ -724,26 +808,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-funspec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -751,37 +839,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-funspec_2.13_3.2.10.jar",
@@ -797,26 +891,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-funsuite_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -824,37 +922,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-funsuite_2.13_3.2.10.jar",
@@ -870,26 +974,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-matchers-core_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -897,37 +1005,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-matchers-core_2.13_3.2.10.jar",
@@ -943,26 +1057,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-mustmatchers_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -970,43 +1088,50 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-mustmatchers_2.13_3.2.10.jar",
@@ -1022,26 +1147,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-propspec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -1049,37 +1178,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-propspec_2.13_3.2.10.jar",
@@ -1095,26 +1230,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-refspec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -1122,37 +1261,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-refspec_2.13_3.2.10.jar",
@@ -1168,26 +1313,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-shouldmatchers_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -1195,43 +1344,50 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-shouldmatchers_2.13_3.2.10.jar",
@@ -1247,26 +1403,30 @@
             "group": "org.scalatest",
             "artifact": "scalatest-wordspec_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -1274,37 +1434,43 @@
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest-wordspec_2.13_3.2.10.jar",
@@ -1320,98 +1486,114 @@
             "group": "org.scalatest",
             "artifact": "scalatest_2.13",
             "version": "3.2.10",
-            "packaging": "jar"
+            "packaging": "jar",
+            "classifier": null
         },
         "directDependencies": [
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-diagrams_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-flatspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-funspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-refspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-wordspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-propspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-shouldmatchers_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-mustmatchers_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-freespec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-funsuite_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-featurespec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "dependencies": [
@@ -1419,109 +1601,127 @@
                 "group": "org.scalatest",
                 "artifact": "scalatest-diagrams_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-flatspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-funspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-reflect",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang",
                 "artifact": "scala-library",
                 "version": "2.13.6",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-refspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-wordspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scala-lang.modules",
                 "artifact": "scala-xml_2.13",
                 "version": "1.3.0",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-propspec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-compatible",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-shouldmatchers_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-mustmatchers_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-freespec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-funsuite_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalactic",
                 "artifact": "scalactic_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-matchers-core_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             },
             {
                 "group": "org.scalatest",
                 "artifact": "scalatest-featurespec_2.13",
                 "version": "3.2.10",
-                "packaging": "jar"
+                "packaging": "jar",
+                "classifier": null
             }
         ],
         "file_name": "org.scalatest_scalatest_2.13_3.2.10.jar",

--- a/3rdparty/jvm/org/scala-lang/BUILD
+++ b/3rdparty/jvm/org/scala-lang/BUILD
@@ -1,0 +1,7 @@
+jvm_artifact(
+    name="scala-library",
+    group="org.scala-lang",
+    artifact="scala-library",
+    version="2.13.6",
+    packages=["scala.**"],
+)

--- a/src/jvm/org/pantsbuild/example/app/BUILD
+++ b/src/jvm/org/pantsbuild/example/app/BUILD
@@ -3,5 +3,10 @@ scala_sources()
 deploy_jar(
     name="bin",
     main="org.pantsbuild.example.app.ExampleApp",
-    dependencies=[":app"],
+    dependencies=[
+        ":app",
+        # TODO: This dependency is explicitly declared because it is not currently implicitly/automatically
+        # added for Scala targets. See https://github.com/pantsbuild/pants/issues/14171.
+        "3rdparty/jvm/org/scala-lang:scala-library",
+    ],
 )


### PR DESCRIPTION
As mentioned in the `BUILD` file comment: this is necessary because we do not currently implicitly add this dependency. See https://github.com/pantsbuild/pants/issues/14171.

Fixes #5.