### PR TITLE
Parametrize the JDK used for testing

### DIFF
--- a/pants
+++ b/pants
@@ -16,7 +16,9 @@ set -eou pipefail
 #  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
 #
 # E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
-PANTS_SHA=0c28019796250b5dac84891a14c1cf006183c08c
+
+# TODO: Picks up https://github.com/pantsbuild/pants/pull/14510.
+PANTS_SHA=79fe06e3ce4f16e45e04f59ca61de9fe19e4e216
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 

--- a/pants
+++ b/pants
@@ -16,6 +16,7 @@ set -eou pipefail
 #  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
 #
 # E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+PANTS_SHA=0c28019796250b5dac84891a14c1cf006183c08c
 
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 

--- a/pants
+++ b/pants
@@ -17,9 +17,6 @@ set -eou pipefail
 #
 # E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
 
-# TODO: Picks up https://github.com/pantsbuild/pants/pull/14510.
-PANTS_SHA=79fe06e3ce4f16e45e04f59ca61de9fe19e4e216
-
 PYTHON_BIN_NAME="${PYTHON:-unspecified}"
 
 # Set this to specify a non-standard location for this script to read the Pants version from.

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,1 +1,3 @@
-scalatest_tests()
+scalatest_tests(
+    jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
+)

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,3 +1,8 @@
 scalatest_tests(
-    jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
+    jdk="adopt:1.11",
+)
+
+scalatest_tests(
+    name="tests_adop_1.12",
+    jdk="adopt:1.12.0.2",
 )

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,8 +1,3 @@
 scalatest_tests(
-    jdk="adopt:1.11",
-)
-
-scalatest_tests(
-    name="tests_adop_1.12",
-    jdk="adopt:1.12.0.2",
+    jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
 )

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,3 +1,5 @@
 scalatest_tests(
+    # These tests are `parametrize`d, so that they will run against two different
+    # JDK versions.
     jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
 )


### PR DESCRIPTION
Demonstrates using the [`parametrize` builtin](https://www.pantsbuild.org/v2.11/docs/targets#parametrizing-targets) with the [`jdk` field](https://www.pantsbuild.org/v2.11/docs/reference-scalatest_tests#codejdkcode), to run the same test under multiple JDKs.