### PR TITLE
remove explicit scala-library dep

### DIFF
--- a/src/jvm/org/pantsbuild/example/app/BUILD
+++ b/src/jvm/org/pantsbuild/example/app/BUILD
@@ -5,8 +5,5 @@ deploy_jar(
     main="org.pantsbuild.example.app.ExampleApp",
     dependencies=[
         ":app",
-        # TODO: This dependency is explicitly declared because it is not currently implicitly/automatically
-        # added for Scala targets. See https://github.com/pantsbuild/pants/issues/14171.
-        "3rdparty/jvm/org/scala-lang:scala-library",
     ],
 )


### PR DESCRIPTION
Remove an explicit `scala-library` dep in `deploy_jar` target since Pants was updated a while ago to actually add that dep to Scala targets.