### PR TITLE
Upgrade to pants 2.18.0 and M1-compatible jdk

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.17.0"
+pants_version = "2.18.0"
 backend_packages = [
   # This repository demonstrates a mix of Java and Scala, and so both backends are enabled. But each
   # backend can be used independently, so there is no need to expose Scala BUILD file

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,5 +1,5 @@
 scalatest_tests(
     # These tests are `parametrize`d, so that they will run against two different
     # JDK versions.
-    jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
+    jdk=parametrize(temurin_11="temurin:1.11", temurin_17="temurin:1.17"),
 )


### PR DESCRIPTION
Upgrade to pants 2.18.0

We change the jdks used in the tests to jdks that are also available for arm architectures on mac. the previous `adopt` jdks were not available but pants 2.18.0 now looks for them.

See the discussion in https://github.com/pantsbuild/pants/issues/20174#issuecomment-1810662092 for details of why we are updating the jdks used in the test.

## Testing

On my M2 laptop test, fmt, lint and package all work against `::`